### PR TITLE
Detect unpublished packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const fetchMeta = require('package-json');
 const getPackage = require('./lib/get-package');
 const recentPublish = require('./lib/recent-publish');
 const significantDownloads = require('./lib/significant-downloads');
+const unpublished = require('./lib/unpublished');
 const hasReadme = require('./lib/has-readme');
 const hasBinaryOrDependent = require('./lib/has-binary-or-dependent');
 const hasProdVersion = require('./lib/has-prod-version');
@@ -39,6 +40,11 @@ const squatter = async (name, version = 'latest') => {
         allVersions  : true,
         fullMetadata : true
     });
+
+    if (unpublished(meta)) {
+        return false;
+    }
+
     const pkg = getPackage(meta, version);
 
     const isExempt = await pOne(exemptions, (test) => {

--- a/lib/unpublished.js
+++ b/lib/unpublished.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const unpublished = (meta) => {
+    return Boolean(!meta['dist-tags'] && meta.time && meta.time.unpublished);
+};
+
+module.exports = unpublished;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "squatter",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Check if a namespace on npm is being hogged.",
     "homepage": "https://github.com/sholladay/squatter",
     "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import recentPublish from './lib/recent-publish';
 import significantDownloads from './lib/significant-downloads';
+import unpublished from './lib/unpublished';
 import hasReadme from './lib/has-readme';
 import hasBinaryOrDependent from './lib/has-binary-or-dependent';
 import hasProdVersion from './lib/has-prod-version';
@@ -29,7 +30,8 @@ test('squatter() correctly identifies non-squatters', async (t) => {
         'delivr',
         'semver',
         'got',
-        'ava'
+        'ava',
+        'leopard'
     ];
     await Promise.all(nonSquatters.map(async (pkgName) => {
         t.false(await squatter(pkgName), `${pkgName} must not be a squatter`);
@@ -189,4 +191,15 @@ test('hasExtraMaintainer() looks for multiple maintainers', (t) => {
             { name : 'John Doe' }
         ]
     }));
+});
+
+test('unpublished() looks for missing dist-tags and an unpublished time', (t) => {
+    t.false(unpublished({}));
+    t.false(unpublished({ time : { created : '2018' } }));
+    t.false(unpublished({
+        'dist-tags' : {},
+        time        : { unpublished : '2011' }
+    }));
+
+    t.true(unpublished({ time : { unpublished : '2011' } }));
 });


### PR DESCRIPTION
Fixes #1 

I couldn't unpublish 'sunglasses' 😎 , but I found 'leopard' 🐆 to be unpublished too so I added it to the tests